### PR TITLE
don't attempt to start steam overlay when vrchat is running with --no-vr

### DIFF
--- a/WinApi.cs
+++ b/WinApi.cs
@@ -15,5 +15,8 @@ namespace VRCX
 
         [DllImport("user32.dll")]
         public static extern IntPtr FindWindow(string lpClassName, string lpWindowName);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern UInt32 GetWindowThreadProcessId(IntPtr hWnd, out Int32 lpdwProcessId);
     }
 }


### PR DESCRIPTION
Currently, if you have `SteamVR Overlay` enabled in VRCX and start VRChat in desktop mode, VRCX starts its internal SteamVR overlay driver which causes SteamVR to start up. This patch makes VRCX check if VRChat is running and whether it's currently running in VR or desktop mode before starting up the internal overlay driver.