### PR TITLE
expands avatar favorites from 16 to 25x4

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -2602,14 +2602,14 @@ CefSharp.BindObjectAsync(
         }
         // 16 = ['avatars1'] x 16
         this.favoriteAvatarGroups = [];
-        for (var i = 0; i < 1; ++i) {
+        for (var i = 0; i < 4; ++i) {
             this.favoriteAvatarGroups.push({
                 assign: false,
                 key: `avatar:avatars${i + 1}`,
                 type: 'avatar',
                 name: `avatars${i + 1}`,
                 displayName: `Group ${i + 1}`,
-                capacity: 16,
+                capacity: 25,
                 count: 0
             });
         }


### PR DESCRIPTION
VRChat Plus announced that amount of avatar favorites expand 25 and 4 categories.
In API, It can be use at now, so change these arguments and expand it.
in this pullrequest doesn't check the owner is plus account or not sry ;)
![image](https://user-images.githubusercontent.com/6259214/101019002-a6dd4500-35af-11eb-9ea9-7ed34ed3e5d5.png)
![image](https://user-images.githubusercontent.com/6259214/101019126-d68c4d00-35af-11eb-88ca-5b5498103e14.png)
