### PR TITLE
Change getFaviconUrl to DuckDuckGo #179

### DIFF
--- a/html/src/app.js
+++ b/html/src/app.js
@@ -7966,7 +7966,7 @@ speechSynthesis.getVoices();
     $app.methods.getFaviconUrl = function (resource) {
         try {
             var url = new URL(resource);
-            return `https://www.google.com/s2/favicons?domain=${url.origin}`;
+            return `https://icons.duckduckgo.com/ip2/${url.host}.ico`;
         } catch (err) {
             return '';
         }


### PR DESCRIPTION
Google favicons cannot support all domain.

DuckDuckGo does better.

![](https://icons.duckduckgo.com/ip2/github.com.ico) `https://icons.duckduckgo.com/ip2/github.com.ico`

![](https://www.google.com/s2/favicons?domain=github.com) `https://www.google.com/s2/favicons?domain=github.com`