### PR TITLE
Update installer.nsi

### DIFF
--- a/Installer/installer.nsi
+++ b/Installer/installer.nsi
@@ -106,7 +106,7 @@ Function .onInit
 FunctionEnd
 
 Function createDesktopShortcut
-    CreateShortcut "$DESKTOP\VRCX.lnk" "$INSTDIR\VRCX.exe"
+    CreateShortcut "%USERPROFILE%\DESKTOP\VRCX.lnk" "$INSTDIR\VRCX.exe"
 FunctionEnd
 
 Function launchVRCX

--- a/Installer/installer.nsi
+++ b/Installer/installer.nsi
@@ -106,7 +106,7 @@ Function .onInit
 FunctionEnd
 
 Function createDesktopShortcut
-    SetShellVarContext current
+    SetShellVarContext all
     CreateShortcut "$DESKTOP\VRCX.lnk" "$INSTDIR\VRCX.exe"
 FunctionEnd
 

--- a/Installer/installer.nsi
+++ b/Installer/installer.nsi
@@ -106,7 +106,7 @@ Function .onInit
 FunctionEnd
 
 Function createDesktopShortcut
-    CreateShortcut "%USERPROFILE%\DESKTOP\VRCX.lnk" "$INSTDIR\VRCX.exe"
+    CreateShortcut "$DESKTOP\VRCX.lnk" "$INSTDIR\VRCX.exe"
 FunctionEnd
 
 Function launchVRCX
@@ -152,6 +152,8 @@ Section "Install" SecInstall
     IntFmt $0 "0x%08X" $0
     WriteRegDWORD HKLM  "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "EstimatedSize" "$0"
 
+    ;SetShellVarContext current sets the shortcut to current userspace
+    SetShellVarContext current
     CreateShortCut "$SMPROGRAMS\VRCX.lnk" "$INSTDIR\VRCX.exe"
     ApplicationID::Set "$SMPROGRAMS\VRCX.lnk" "VRCX"
 

--- a/Installer/installer.nsi
+++ b/Installer/installer.nsi
@@ -106,6 +106,7 @@ Function .onInit
 FunctionEnd
 
 Function createDesktopShortcut
+    SetShellVarContext current
     CreateShortcut "$DESKTOP\VRCX.lnk" "$INSTDIR\VRCX.exe"
 FunctionEnd
 
@@ -152,8 +153,6 @@ Section "Install" SecInstall
     IntFmt $0 "0x%08X" $0
     WriteRegDWORD HKLM  "Software\Microsoft\Windows\CurrentVersion\Uninstall\VRCX" "EstimatedSize" "$0"
 
-    ;SetShellVarContext current sets the shortcut to current userspace
-    SetShellVarContext current
     CreateShortCut "$SMPROGRAMS\VRCX.lnk" "$INSTDIR\VRCX.exe"
     ApplicationID::Set "$SMPROGRAMS\VRCX.lnk" "VRCX"
 


### PR DESCRIPTION
Fixed desktop shortcut icon installer by changing the installer desktop function to only apply on the current active users desktop. Bug was found while installing VRCX on my user account and noticing the shortcut only going to my admins desktop.
fixes #344 