### PR TITLE
(Minor) Added argument to set VROverlay GPU to index

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -17,7 +17,7 @@ namespace VRCX
         public static string ConfigLocation;
         public static string Version { get; private set; }
         public static bool LaunchDebug;
-
+        public static bool GPUFix;
         static Program()
         {
             BaseDirectory = AppDomain.CurrentDomain.BaseDirectory;

--- a/StartupArgs.cs
+++ b/StartupArgs.cs
@@ -24,6 +24,7 @@ namespace VRCX
 
             foreach (string arg in args)
             {
+                if (arg.Contains("--gpufix")) Program.GPUFix = true;
                 if (arg.Length > 12 && arg.Substring(0, 12) == "/uri=vrcx://")
                     LaunchCommand = arg.Substring(12);
 

--- a/VRCXVR.cs
+++ b/VRCXVR.cs
@@ -89,20 +89,10 @@ namespace VRCX
             // REMOVE THIS
             // nextOverlay = DateTime.MaxValue;
             // https://stackoverflow.com/questions/38312597/how-to-choose-a-specific-graphics-device-in-sharpdx-directx-11/38596725#38596725
-            SharpDX.DXGI.Factory f = new SharpDX.DXGI.Factory1();
-            SharpDX.DXGI.Adapter a = f.GetAdapter(1);
-            FeatureLevel[] levels = new FeatureLevel[]
-            {
-#if DIRECTX11_1
-    FeatureLevel.Level_11_1,
-#endif
-                FeatureLevel.Level_11_0,
-                FeatureLevel.Level_10_1,
-                FeatureLevel.Level_10_0,
-                FeatureLevel.Level_9_3
-            };
+            Factory f = new Factory1();
+            Adapter a = f.GetAdapter(1);
+            
             DeviceCreationFlags flags = DeviceCreationFlags.BgraSupport;
-            // _device = new Device(a, flags, levels);
 
             _device = Program.GPUFix ? new Device(a, flags) : new Device(DriverType.Hardware, DeviceCreationFlags.SingleThreaded | DeviceCreationFlags.BgraSupport);
 

--- a/VRCXVR.cs
+++ b/VRCXVR.cs
@@ -88,11 +88,23 @@ namespace VRCX
 
             // REMOVE THIS
             // nextOverlay = DateTime.MaxValue;
+            // https://stackoverflow.com/questions/38312597/how-to-choose-a-specific-graphics-device-in-sharpdx-directx-11/38596725#38596725
+            SharpDX.DXGI.Factory f = new SharpDX.DXGI.Factory1();
+            SharpDX.DXGI.Adapter a = f.GetAdapter(1);
+            FeatureLevel[] levels = new FeatureLevel[]
+            {
+#if DIRECTX11_1
+    FeatureLevel.Level_11_1,
+#endif
+                FeatureLevel.Level_11_0,
+                FeatureLevel.Level_10_1,
+                FeatureLevel.Level_10_0,
+                FeatureLevel.Level_9_3
+            };
+            DeviceCreationFlags flags = DeviceCreationFlags.BgraSupport;
+            // _device = new Device(a, flags, levels);
 
-            _device = new Device(
-                DriverType.Hardware,
-                DeviceCreationFlags.SingleThreaded | DeviceCreationFlags.BgraSupport
-            );
+            _device = Program.GPUFix ? new Device(a, flags) : new Device(DriverType.Hardware, DeviceCreationFlags.SingleThreaded | DeviceCreationFlags.BgraSupport);
 
             _texture1 = new Texture2D(
                 _device,


### PR DESCRIPTION
Adds argument `--gpufix` which sets the rendering GPU of VRCX overlay to index 1 which forces the overlay to render to the second or if your using an Integrated GPU it will force rendering on your dedicated GPU 